### PR TITLE
Add TypeScript declaration file to module entrypoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.0.5] - 2020-03-17
 ### Fixed
 - Include `index.d.ts` in `files` of `package.json`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Include `index.d.ts` in `files` of `package.json`.
 
 ## [1.0.4] - 2020-03-17
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.4] - 2020-03-17
+### Added
+- TypeScript declaration file entrypoint `index.d.ts`.

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,8 @@
+interface Msk {
+  (str: string, mask: string): string
+  fit: (str: string, mask: string) => string
+}
+
+declare const msk: Msk
+
+export default msk

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "msk",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Small library to mask strings",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "msk",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Small library to mask strings",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "module": "dist/index.esm.js",
   "browser": "dist/index.umd.js",
   "files": [
-    "dist"
+    "dist",
+    "index.d.ts"
   ],
   "scripts": {
     "test": "jest",


### PR DESCRIPTION
This PR adds the TypeScript module declaration file to the entrypoint, so developers that are using TypeScript can benefit of autocomplete and type definitions.